### PR TITLE
dist: officially release v1.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ if(COMMAND cmake_minimum_required)
 endif(COMMAND cmake_minimum_required)
 
 PROJECT(typelib)
-SET(PROJECT_VERSION 1.1)
+SET(PROJECT_VERSION 1.2)
 SET(API_VERSION 1)
 
 #required because of the use of std::unique_ptr


### PR DESCRIPTION
This is a first small step in the right direction, that is of creating
proper releases of the rock-core packages. Since typelib staid on v1.1
since ... forever, let's release v1.2 now and start from there.