### PR TITLE
CSVOutput: Output strings as single fields instead of char-wise

### DIFF
--- a/typelib/csvoutput.cc
+++ b/typelib/csvoutput.cc
@@ -86,6 +86,7 @@ namespace
     {
         list<string>  m_output;
         bool m_char_as_numeric;
+        std::string m_string_delimeter;
 
     protected:
         template<typename T>
@@ -99,6 +100,18 @@ namespace
         {
             display("<" + type.getName() + ">");
             return true;
+        }
+        virtual bool visit_ (Value const& v, Container const& a)
+        {
+            if (a.getName() == "/std/string"){
+                std::string* string_ptr =
+                    reinterpret_cast< std::string* >(v.getData());
+                m_output.push_back(m_string_delimeter + *string_ptr + m_string_delimeter);
+
+                return true;
+            }
+
+           return ValueVisitor::visit_(v,a);
         }
         bool visit_ (int8_t  & value)
         {
@@ -131,10 +144,11 @@ namespace
         }
 
     public:
-        list<string> apply(Value const& value, bool char_as_numeric)
+        list<string> apply(Value const& value, bool char_as_numeric, std::string string_delimeter)
         {
             m_output.clear();
             m_char_as_numeric = char_as_numeric;
+            m_string_delimeter = string_delimeter;
             ValueVisitor::apply(value);
             return m_output;
         }
@@ -142,8 +156,8 @@ namespace
 }
 
 
-CSVOutput::CSVOutput(Type const& type, std::string const& sep, bool char_as_numeric = true)
-    : m_type(type), m_separator(sep), m_char_as_numeric(char_as_numeric) {}
+CSVOutput::CSVOutput(Type const& type, std::string const& sep, bool char_as_numeric = true, const string &string_delim)
+    : m_type(type), m_separator(sep), m_char_as_numeric(char_as_numeric), m_string_delimeter(string_delim) {}
 
 /** Displays the header */
 void CSVOutput::header(std::ostream& out, std::string const& basename)
@@ -155,6 +169,6 @@ void CSVOutput::header(std::ostream& out, std::string const& basename)
 void CSVOutput::display(std::ostream& out, void* value)
 {
     LineVisitor visitor;
-    out << join(visitor.apply( Value(value, m_type), m_char_as_numeric ), m_separator );
+    out << join(visitor.apply( Value(value, m_type), m_char_as_numeric, m_string_delimeter), m_separator );
 }
 

--- a/typelib/csvoutput.hh
+++ b/typelib/csvoutput.hh
@@ -12,9 +12,10 @@ namespace Typelib
         Type const& m_type;
         std::string m_separator;
         bool m_char_as_numeric;
+        std::string m_string_delimeter;
 
     public:
-        CSVOutput(Type const& type, std::string const& sep, bool char_as_numeric);
+        CSVOutput(Type const& type, std::string const& sep, bool char_as_numeric, std::string const& string_delim = "");
 
         /** Displays the header */
         void header(std::ostream& out, std::string const& basename);
@@ -28,8 +29,8 @@ namespace Typelib
             CSVOutput output;
             std::string basename;
 
-            csvheader(Type const& type, std::string const& basename_, std::string const& sep = " ")
-                : output(type, sep, true), basename(basename_) {}
+            csvheader(Type const& type, std::string const& basename_, std::string const& sep = " ", std::string const& string_delim = "")
+                : output(type, sep, true, string_delim), basename(basename_) {}
         };
         struct csvline
         {
@@ -37,8 +38,8 @@ namespace Typelib
             void* value;
             bool char_as_numeric;
 
-            csvline(Type const& type_, void* value_, std::string const& sep_ = " ", bool char_as_numeric = true)
-                : output(type_, sep_, char_as_numeric), value(value_), char_as_numeric(char_as_numeric) {}
+            csvline(Type const& type_, void* value_, std::string const& sep_ = " ", bool char_as_numeric = true, std::string const& string_delim = "")
+                : output(type_, sep_, char_as_numeric, string_delim), value(value_), char_as_numeric(char_as_numeric) {}
         };
         inline std::ostream& operator << (std::ostream& stream, csvheader header)
         {
@@ -57,16 +58,16 @@ namespace Typelib
      * @arg basename    the basename to use. For simple type, it is the variable name. For compound types, names in the header are &lt;basename&gt;.&lt;fieldname&gt;
      * @arg sep         the separator to use
      */
-    inline details::csvheader csv_header(Type const& type, std::string const& basename, std::string const& sep = " ")
-    { return details::csvheader(type, basename, sep); }
+    inline details::csvheader csv_header(Type const& type, std::string const& basename, std::string const& sep = " ", std::string const& string_delim="")
+    { return details::csvheader(type, basename, sep, string_delim); }
 
     /** Display a CSV line for a Type object and some raw data
      * @arg type        the data type
      * @arg value       the data as a void* pointer
      * @arg sep         the separator to use
      */
-    inline details::csvline   csv(Type const& type, void* value, std::string const& sep = " ", bool char_as_numeric = true)
-    { return details::csvline(type, value, sep, char_as_numeric); }
+    inline details::csvline   csv(Type const& type, void* value, std::string const& sep = " ", bool char_as_numeric = true, std::string const& string_delim="")
+    { return details::csvline(type, value, sep, char_as_numeric, string_delim); }
 };
 
 #endif


### PR DESCRIPTION
When doing CSV export strings were printed char-wise as individual columns. This patch now prints strings in a single column and also allows to specify a delimiter that is printed around the string.