### PR TITLE
fix(ruby): make sure Type#inspect does not fail if #to_simple_value does

### DIFF
--- a/bindings/ruby/lib/typelib/type.rb
+++ b/bindings/ruby/lib/typelib/type.rb
@@ -792,7 +792,14 @@ module Typelib
         end
 
         def inspect
-            raw_to_s + ": " + to_simple_value.inspect
+            value =
+                begin
+                    ": " + to_simple_value.inspect
+                rescue
+                    ""
+                end
+
+            raw_to_s + value
         end
 
         # Returns a representation of this type only into simple Ruby values,

--- a/test/ruby/test_type.rb
+++ b/test/ruby/test_type.rb
@@ -139,4 +139,25 @@ class TC_Type < Minitest::Test
         assert_equal 10, unmarshalled.a
         assert_in_delta 20, unmarshalled.b, 0.001
     end
+
+    def test_inspect_shows_to_simple_value
+        reg = Typelib::CXXRegistry.new
+        type = reg.create_compound "/Source" do |c|
+            c.add "a", "/int32_t", 0
+            c.add "b", "/double", 10
+        end
+        value = type.new(a: 10, b: 20)
+        assert_equal "#{value}: {\"a\"=>10, \"b\"=>20.0}", value.inspect
+    end
+
+    def test_inspect_does_not_fail_if_to_simple_value_does
+        reg = Typelib::CXXRegistry.new
+        type = reg.create_compound "/Source" do |c|
+            c.add "a", "/int32_t", 0
+            c.add "b", "/double", 10
+        end
+        value = type.new(a: 10, b: 20)
+        flexmock(value).should_receive(:to_simple_value).and_raise(RuntimeError)
+        assert_equal value.to_s, value.inspect
+    end
 end


### PR DESCRIPTION
'inspect' is commonly involved in Ruby standard error displays. This patch avoids that a bad conversion routine, or an invalid "ruby converted value" triggers an error in inspect that would hide the original "real" error.