### PR TITLE
fix: create one and only one PluginManager in a Ruby process

### DIFF
--- a/bindings/ruby/ext/registry.cc
+++ b/bindings/ruby/ext/registry.cc
@@ -704,8 +704,15 @@ static VALUE registry_create_null(VALUE registry, VALUE _name)
     return cxx2rb::type_wrap(*type, registry);
 }
 
+static void detach_typelib_pluginmanager(VALUE) {
+    utilmm::singleton::wrapper<Typelib::PluginManager>::detach();
+}
+
 void typelib_ruby::Typelib_init_registry()
 {
+    utilmm::singleton::wrapper<Typelib::PluginManager>::attach();
+    rb_set_end_proc(detach_typelib_pluginmanager, Qnil);
+
     VALUE mTypelib  = rb_define_module("Typelib");
     cRegistry = rb_define_class_under(mTypelib, "Registry", rb_cObject);
     eNotFound = rb_define_class_under(mTypelib, "NotFound", rb_eRuntimeError);


### PR DESCRIPTION
Typelib::PluginManager is managed as a phoenix singleton, which means that it is destroyed whenever it is not in use. Within the Ruby extension, this means that we create one every time we create a Registry object - and creating one is expensive, given that it looks for plugins in a PATH every time.

Moreover, it is not thread safe - two C++ registry objects created more or less at the same time in two different threads could lead to crashes.